### PR TITLE
Fix/email subject and missing info variable

### DIFF
--- a/app/controllers/decidim/admin_multi_factor/admin/email_strategy_controller.rb
+++ b/app/controllers/decidim/admin_multi_factor/admin/email_strategy_controller.rb
@@ -29,6 +29,7 @@ module Decidim
           return redirect_to decidim_admin_multi_factor_admin.elevate_path if auth_session.blank?
 
           @form = form(::Decidim::AdminMultiFactor::VerificationCodeForm).instance
+          @info = current_user.email
         end
 
         protected

--- a/app/controllers/decidim/admin_multi_factor/admin/sms_strategy_controller.rb
+++ b/app/controllers/decidim/admin_multi_factor/admin/sms_strategy_controller.rb
@@ -35,6 +35,7 @@ module Decidim
 
         def verify_sms_code
           @form = form(::Decidim::AdminMultiFactor::VerificationCodeForm).instance
+          @info = current_user.email
         end
 
         protected

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -58,6 +58,9 @@ de:
             resend_code: Code erneut senden
             submit: Absenden
             welcome: Willkommen auf der <br><strong>%{organization}-Plattform!</strong>
+      admin_multi_factor:
+        email:
+          subject: 'Ihr Authentifizierungscode lautet: %{verification}'
     components:
       admin_multi_factor:
         name: Admin-Mehrfaktor

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,9 @@ en:
             resend_code: Resend code
             submit: Submit
             welcome: Welcome to the <br><strong>%{organization} platform!</strong>
+      admin_multi_factor:
+        email:
+          subject: 'Your auth code is: %{verification}'
     components:
       admin_multi_factor:
         name: AdminMultiFactor

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -58,6 +58,9 @@ fr:
             resend_code: Renvoyer le code
             submit: Soumettre
             welcome: Bienvenue sur la plateforme <br><strong>%{organization} !</strong>
+      admin_multi_factor:
+        email:
+          subject: 'Votre code d''authentification est : %{verification}'
     components:
       admin_multi_factor:
         name: AdminMultiFactor


### PR DESCRIPTION
🎩 Description
The aim of this PR is to add a missing translation for email subject, and a missing info variable in controllers, to rc-0.27.4 branch of the module.

📌 Related Issues
[Odoo card](https://opensourcepolitics.odoo.com/odoo/all-tasks/3936)

Testing
Log in as admin and access back office
In the settings, go to Multifactors settings, check the 3 checkboxes and update (see screenshot)
Log out
Log in again and try to access admin dashboard from the menu
Choose email and go to letter_opener 
Check in the email that the subject is correctly filled
In the page where you insert the received code, check that the email is present in the sentence "You should have received the code to ..." above the inputs for the code.
See that you get access to BO
